### PR TITLE
Add handler registration and unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ build/Release
 
 # Dependency directories
 node_modules/
+!test/node_modules/
 jspm_packages/
 
 # Snowpack dependency directory (https://snowpack.dev/)

--- a/README.md
+++ b/README.md
@@ -252,3 +252,12 @@ graph TD
     Q --> R[Register Route / Prepare Handler];
     R --> S[End Processing];
 ```
+
+## Development
+
+Install dependencies and build the plugin:
+```bash
+pnpm install
+pnpm run build
+```
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "nitro-quill",
+  "version": "0.1.0",
+  "description": "Nitro plugin that turns SQL files into API endpoints",
+  "main": "dist/module.js",
+  "types": "dist/module.d.ts",
+  "scripts": {
+    "build": "tsup src/module.ts --dts --format esm,cjs --out-dir dist",
+    "dev": "tsup src/module.ts --watch --dts --format esm,cjs --out-dir dist",
+    "test": "node test/registration.test.mjs"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "camelcase": "^7.0.0",
+    "globby": "^13.2.2",
+    "mssql": "^9.0.1"
+  },
+  "peerDependencies": {
+    "nitropack": "^2.0.0"
+  },
+  "devDependencies": {
+    "tsup": "^7.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,0 +1,50 @@
+import { join } from 'path'
+import camelCase from 'camelcase'
+import globby from 'globby'
+import type { Nitro } from 'nitropack'
+
+export interface NitroQuillOptions {
+  /** Directory containing SQL files relative to project root. Default: `api` */
+  directory?: string
+}
+
+/**
+ * Nitro plugin that scans a directory for `.sql` files and registers basic
+ * API routes. Real SQL execution is left for future implementation.
+ */
+export default function nitroQuill(nitro: Nitro, options: NitroQuillOptions = {}) {
+  const scanDir = options.directory || 'api'
+
+  nitro.hooks.hook('nitro:build:before', async () => {
+    const base = join(nitro.options.rootDir, scanDir)
+    const files = await globby('**/*.sql', { cwd: base })
+
+    nitro.options.virtual = nitro.options.virtual || {}
+    nitro.options.handlers = nitro.options.handlers || []
+
+    for (const file of files) {
+      const routeName = file.replace(/\.sql$/, '')
+      const segments = routeName.split(/[\\/]/).map((s) => camelCase(s))
+      const routePath = '/' + [scanDir, ...segments].join('/')
+
+      const handlerId = `nitro-quill:${file}`.replace(/[\\/]/g, '-')
+      const virtualPath = `${handlerId}.ts`
+      nitro.options.virtual![virtualPath] = createHandler(join(base, file))
+      nitro.options.handlers.push({
+        route: routePath,
+        method: 'get',
+        handler: virtualPath
+      })
+    }
+  })
+}
+
+function createHandler(sqlFile: string): string {
+  return `import { defineEventHandler } from 'h3'
+import { promises as fsp } from 'fs'
+export default defineEventHandler(async () => {
+  // TODO: parse directives and execute SQL against MSSQL
+  // placeholder simply returns the SQL file path
+  return { ok: true, file: ${JSON.stringify(sqlFile)} }
+})`
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,0 +1,5 @@
+import { defineNitroPlugin } from 'nitropack'
+
+export default defineNitroPlugin((nitro) => {
+  // Placeholder runtime plugin. Real logic will execute generated SQL handlers.
+})

--- a/test/node_modules/camelcase/index.js
+++ b/test/node_modules/camelcase/index.js
@@ -1,0 +1,1 @@
+module.exports = function(str){return str.replace(/[-_](\w)/g,(_,c)=>c.toUpperCase());}

--- a/test/node_modules/camelcase/package.json
+++ b/test/node_modules/camelcase/package.json
@@ -1,0 +1,1 @@
+{"name":"camelcase","main":"index.js"}

--- a/test/node_modules/globby/index.js
+++ b/test/node_modules/globby/index.js
@@ -1,0 +1,1 @@
+const fs=require('fs'),path=require('path');module.exports=async function(pattern,{cwd}){const res=[];function walk(dir){for(const f of fs.readdirSync(path.join(cwd,dir))){const p=path.join(dir,f);const stat=fs.statSync(path.join(cwd,p));if(stat.isDirectory())walk(p);else if(p.endsWith('.sql'))res.push(p);} }walk('');return res;};

--- a/test/node_modules/globby/package.json
+++ b/test/node_modules/globby/package.json
@@ -1,0 +1,1 @@
+{"name":"globby","main":"index.js"}

--- a/test/registration.test.mjs
+++ b/test/registration.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import nitroQuillImport from '../dist/module.js';
+const nitroQuill = nitroQuillImport.default || nitroQuillImport;
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'quill-'));
+fs.mkdirSync(path.join(tmp, 'api'));
+fs.writeFileSync(path.join(tmp, 'api', 'get_users.sql'), 'SELECT 1;');
+fs.mkdirSync(path.join(tmp, 'api', 'admin'));
+fs.writeFileSync(path.join(tmp, 'api', 'admin', 'get_admin.sql'), 'SELECT 1;');
+
+const nitro = {
+  options: { rootDir: tmp, virtual: {}, handlers: [] },
+  hooks: { fn: null, hook(event, cb){ if(event==='nitro:build:before') this.fn = cb; } }
+};
+
+nitroQuill(nitro, {});
+await nitro.hooks.fn();
+assert.strictEqual(nitro.options.handlers.length, 2);
+const routes = nitro.options.handlers.map(h=>h.route).sort();
+assert.deepStrictEqual(routes, ['/api/admin/getAdmin', '/api/getUsers']);
+console.log('ok');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "declaration": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- ensure `nitro.options` containers are initialized and register handlers during build
- add basic unit test covering handler registration
- wire test script in `package.json`
- allow test fixtures in `test/node_modules` via `.gitignore`

## Testing
- `npm test`