### PR TITLE
Configure releases to GitHub only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,3 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -6,6 +6,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm"
+    "@semantic-release/github"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "semantic-release": "^22.0.0",
     "@semantic-release/commit-analyzer": "^11.0.0",
     "@semantic-release/release-notes-generator": "^12.0.0",
-    "@semantic-release/npm": "^10.0.0"
+    "@semantic-release/github": "^8.0.7"
   }
 }


### PR DESCRIPTION
## Summary
- stop publishing to npm
- keep semantic-release for tagging and creating GitHub releases only

## Testing
- `pnpm run test`